### PR TITLE
Add missing requirements to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 beautifulsoup4
 ebooklib
 edge-tts
+lxml
 mutagen
 nltk
+pillow
 pydub
+setuptools


### PR DESCRIPTION
The 20240502 update to add cover art functionality requires the pillow library, and Python may have issues if this is not already installed in the environment. I added the requirement to the requirements.txt, as well as a few other packages that were missing.