### PR TITLE
Retrieve epub documents in spine order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-edge",
     license="GPL 3.0",
-    version="1.2.1",
+    version="1.2.2",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
The epub to text conversion was not extracting text in anything resembling chapter order on a few epubs that I tried it with.

The root cause is that the items listed in the manifest are not similar to the order listed in the book's spine.

Below is an excerpt of a `content.opf` file from one of the books. Notice how all the content inserts are listed before any chapters but should be interleaved between chapters. Also notice that the inserts are not even in order (in the below example the sequence is 6,1,2,3,4,5,7,8 in the manifest).

To resolve this issue, we iterate though the content IDs in the spine and index into a dictionary indexing all manifest items of type `ebooklib.ITEM_DOCUMENT`.

```xml
  <manifest>
    <item id="cover" href="Text/cover.xhtml" media-type="application/xhtml+xml"/>
    <item id="style" href="Styles/stylesheet.css" media-type="text/css"/>
    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
    <item id="toc" href="Text/toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
    <item id="tocimg.xhtml" href="Text/tocimg.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert6.xhtml" href="Text/insert6.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert1.xhtml" href="Text/insert1.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert2.xhtml" href="Text/insert2.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert3.xhtml" href="Text/insert3.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert4.xhtml" href="Text/insert4.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert5.xhtml" href="Text/insert5.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert7.xhtml" href="Text/insert7.xhtml" media-type="application/xhtml+xml"/>
    <item id="insert8.xhtml" href="Text/insert8.xhtml" media-type="application/xhtml+xml"/>
    <item id="TOC.jpg" href="Images/TOC.jpg" media-type="image/jpeg"/>
    <item id="chapter1_2.xhtml" href="Text/chapter1_2.xhtml" media-type="application/xhtml+xml"/>
    <item id="chapter2_1.xhtml" href="Text/chapter2_1.xhtml" media-type="application/xhtml+xml"/>
    [...]
  </manifest>
  <spine page-progression-direction="ltr" toc="ncx">
    <itemref idref="cover"/>
    <itemref idref="tocimg.xhtml"/>
    <itemref idref="characters1.xhtml"/>
    <itemref idref="characters2.xhtml"/>
    <itemref idref="chapter1.xhtml"/>
    <itemref idref="insert1.xhtml"/>
    <itemref idref="chapter1_1.xhtml"/>
    <itemref idref="insert2.xhtml"/>
    <itemref idref="chapter1_2.xhtml"/>
    <itemref idref="chapter2.xhtml"/>
    <itemref idref="insert3.xhtml"/>
    <itemref idref="chapter2_1.xhtml"/>
    [...]
</spine>
```