### PR TITLE
Change the way titles are handled, and fix cover image path issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 
 *NOTE:* If you want to specify where NLTK tokenizer will be stored (about 50mb), use an environment variable: `export NLTK_DATA="your/path/to/nltk_data"`
 
+## OPTIONAL - activate the virutal environment if using
+1. `source .venv/bin/activate`
+
 ## FIRST - extract epub contents to text and cover image to png:
 1. `epub2tts-edge mybook.epub`
 2. **edit mybook.txt**, replacing `# Part 1` etc with desired chapter names, and removing front matter like table of contents and anything else you do not want read. **Note:** First two lines can be Title: and Author: to use that in audiobook metadata.
@@ -34,6 +37,8 @@
 * `--paragraphpause <N>` - number of milliseconds to pause between paragraphs
 * `--sentencepause <N>` - number of milliseconds to pause between sentences
 
+## Deactivate virtual environment
+`deactivate`
 </details>
 
 ## 🐞 Reporting bugs
@@ -92,14 +97,16 @@ pip install .
 <details>
 <summary>LINUX INSTALLATION</summary>
 
-These instructions are for Ubuntu 22.04 (20.04 showed some depedency issues), but should work (with appropriate package installer mods) for just about any repo. Ensure you have `ffmpeg` installed before use.
+These instructions are for Ubuntu 24.04.1 LTS and 22.04  (20.04 showed some depedency issues), but should work (with appropriate package installer mods) for just about any distro. Ensure you have `ffmpeg` installed before use.
 
 ```
 #install dependencies
-sudo apt install espeak-ng ffmpeg
+sudo apt install espeak-ng ffmpeg python3-venv
 #clone the repo
 git clone https://github.com/aedocw/epub2tts-edge
 cd epub2tts-edge
+#OPTIONAL - install this in a virtual environment
+python3 -m venv .venv && source .venv/bin/activate
 pip install .
 ```
 
@@ -108,7 +115,7 @@ pip install .
 <details>
 <summary>WINDOWS INSTALLATION</summary>
 
-Runnig epub2tts in WSL2 with Ubuntu 22 is the easiest approach, but these steps should work for running directly in windows.
+Running epub2tts in WSL2 with Ubuntu 22 is the easiest approach, but these steps should work for running directly in windows.
 
 (TBD)
 
@@ -122,7 +129,7 @@ Runnig epub2tts in WSL2 with Ubuntu 22 is the easiest approach, but these steps 
 
 1. cd to repo directory
 2. `git pull`
-3. Activate virtual environment you installed epub2tts in if you installed in a virtual environment
+3. Activate virtual environment you installed epub2tts in if you installed in a virtual environment using "source .venv/bin/activate"
 4. `pip install . --upgrade`
 </details>
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 * `-h, --help` - show this help message and exit
 * `--speaker SPEAKER` - Speaker to use (example: en-US-EricNeural)
 * `--cover image.[jpg|png]` - image to use for cover
+* `--paragraphpause <N>` - number of milliseconds to pause between paragraphs
+* `--sentencepause <N>` - number of milliseconds to pause between sentences
 
 </details>
 

--- a/epub2tts_edge/epub2tts_edge.py
+++ b/epub2tts_edge/epub2tts_edge.py
@@ -139,9 +139,9 @@ def export(book, sourcefile):
     author = book.get_metadata("DC", "creator")[0][0]
     booktitle = book.get_metadata("DC", "title")[0][0]
 
-    with open(outfile, "w") as file:
-        file.write(f"Title: {booktitle}\n")
-        file.write(f"Author: {author}\n\n")
+    with open(outfile, "w", encoding='utf-8') as file:
+        file.write(f"# Title\n")
+        file.write(f"{booktitle}, by {author}\n\n")
         for i, chapter in enumerate(book_contents, start=1):
             if chapter["paragraphs"] == [] or chapter["paragraphs"] == ['']:
                 continue
@@ -152,6 +152,8 @@ def export(book, sourcefile):
                     file.write(f"# {chapter['title']}\n\n")
                 for paragraph in chapter["paragraphs"]:
                     clean = re.sub(r'[\s\n]+', ' ', paragraph)
+                    clean = re.sub(r'[“”]', '"', clean)  # Curly double quotes to standard double quotes
+                    clean = re.sub(r'[‘’]', "'", clean)  # Curly single quotes to standard single quotes
                     file.write(f"{clean}\n\n")
 
 def get_book(sourcefile):
@@ -237,10 +239,18 @@ def read_book(book_contents, speaker, paragraphpause, sentencepause):
             print(f"Chapter: {chapter['title']}\n")
             if chapter["title"] == "":
                 chapter["title"] = "blank"
+<<<<<<< HEAD
             asyncio.run(
                 parallel_edgespeak([chapter["title"]], [speaker], ["sntnc0.mp3"])
             )
             append_silence("sntnc0.mp3", sentencepause)
+=======
+            if chapter["title"] != "Title":
+                asyncio.run(
+                    parallel_edgespeak([chapter["title"]], [speaker], ["sntnc0.mp3"])
+                )
+                append_silence("sntnc0.mp3", 1200)
+>>>>>>> 6493cdf (Change handling of title in txt writing and in reading.)
             for pindex, paragraph in enumerate(
                 tqdm(chapter["paragraphs"], desc=f"Processing chapter {i}",unit='pg')
             ):

--- a/epub2tts_edge/epub2tts_edge.py
+++ b/epub2tts_edge/epub2tts_edge.py
@@ -39,6 +39,10 @@ def ensure_punkt():
         nltk.data.find("tokenizers/punkt")
     except LookupError:
         nltk.download("punkt")
+    try:
+        nltk.data.find("tokenizers/punkt_tab")
+    except LookupError:
+        nltk.download("punkt_tab")
 
 def chap2text_epub(chap):
     blacklist = [

--- a/epub2tts_edge/epub2tts_edge.py
+++ b/epub2tts_edge/epub2tts_edge.py
@@ -224,7 +224,7 @@ def append_silence(tempfile, duration=1200):
     # Save the combined audio back to file
     combined.export(tempfile, format="flac")
 
-def read_book(book_contents, speaker, pause):
+def read_book(book_contents, speaker, paragraphpause, sentencepause):
     segments = []
     for i, chapter in enumerate(book_contents, start=1):
         files = []
@@ -239,7 +239,7 @@ def read_book(book_contents, speaker, pause):
             asyncio.run(
                 parallel_edgespeak([chapter["title"]], [speaker], ["sntnc0.mp3"])
             )
-            append_silence("sntnc0.mp3", 1200)
+            append_silence("sntnc0.mp3", sentencepause)
             for pindex, paragraph in enumerate(
                 tqdm(chapter["paragraphs"], desc=f"Processing chapter {i}",unit='pg')
             ):
@@ -253,7 +253,7 @@ def read_book(book_contents, speaker, pause):
                     ]
                     speakers = [speaker] * len(sentences)
                     asyncio.run(parallel_edgespeak(sentences, speakers, filenames))
-                    append_silence(filenames[-1], pause)
+                    append_silence(filenames[-1], paragraphpause)
                     # combine sentences in paragraph
                     sorted_files = sorted(filenames, key=sort_key)
                     if os.path.exists("sntnc0.mp3"):
@@ -411,11 +411,18 @@ def main():
         help="jpg image to use for cover",
     )
     parser.add_argument(
-        "--pause",
+        "--sentencepause",
         type=int,
         default=1200,
-        help="duration of pause in milliseconds (default: 1200)"
+        help="duration of pause after sentence, in milliseconds (default: 1200)"
     )
+    parser.add_argument(
+        "--paragraphpause",
+        type=int,
+        default=1200,
+        help="duration of pause after paragraph, in milliseconds (default: 1200)"
+    )
+
 
     args = parser.parse_args()
     print(args)
@@ -429,7 +436,7 @@ def main():
         exit()
 
     book_contents, book_title, book_author, chapter_titles = get_book(args.sourcefile)
-    files = read_book(book_contents, args.speaker, args.pause)
+    files = read_book(book_contents, args.speaker, args.paragraphpause, args.sentencepause)
     generate_metadata(files, book_author, book_title, chapter_titles)
     m4bfilename = make_m4b(files, args.sourcefile, args.speaker)
     add_cover(args.cover, m4bfilename)

--- a/epub2tts_edge/epub2tts_edge.py
+++ b/epub2tts_edge/epub2tts_edge.py
@@ -99,7 +99,8 @@ def get_epub_cover(epub_path):
                 return None
             cover_href = cover_item[0].get("href")
             cover_path = os.path.join(os.path.dirname(rootfile_path), cover_href)
-
+            if os.name == 'nt' and '\\' in cover_path:
+                cover_path = cover_path.replace("\\", "/")
             return z.open(cover_path)
     except FileNotFoundError:
         print(f"Could not get cover image of {epub_path}")

--- a/epub2tts_edge/epub2tts_edge.py
+++ b/epub2tts_edge/epub2tts_edge.py
@@ -239,18 +239,11 @@ def read_book(book_contents, speaker, paragraphpause, sentencepause):
             print(f"Chapter: {chapter['title']}\n")
             if chapter["title"] == "":
                 chapter["title"] = "blank"
-<<<<<<< HEAD
-            asyncio.run(
-                parallel_edgespeak([chapter["title"]], [speaker], ["sntnc0.mp3"])
-            )
-            append_silence("sntnc0.mp3", sentencepause)
-=======
             if chapter["title"] != "Title":
                 asyncio.run(
                     parallel_edgespeak([chapter["title"]], [speaker], ["sntnc0.mp3"])
                 )
                 append_silence("sntnc0.mp3", 1200)
->>>>>>> 6493cdf (Change handling of title in txt writing and in reading.)
             for pindex, paragraph in enumerate(
                 tqdm(chapter["paragraphs"], desc=f"Processing chapter {i}",unit='pg')
             ):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-edge",
     license="GPL 3.0",
-    version="1.2.2",
+    version="1.2.3",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-edge",
     license="GPL 3.0",
-    version="1.2.3",
+    version="1.2.4",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-edge",
     license="GPL 3.0",
-    version="1.2.5",
+    version="1.2.6",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="c@aedo.dev",
     url="https://github.com/aedocw/epub2tts-edge",
     license="GPL 3.0",
-    version="1.2.4",
+    version="1.2.5",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
Fixed an issue where a cover.jpg would fail to be extracted. I think this is related to how paths are found/generated on Windows so it's scoped just to Windows.

The other change is in how the title/author is handled. It now writes out as:
```
# Title
Title of Book, by Author
```

This, along with the change in how the audio is generated, allows for a book to begin with a title "chapter".  (i.e.  The audiobook starts by saying "Book Title, by Author.  ... Chapter 1, lorem ipsum...")